### PR TITLE
Add cart validation tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -289,7 +289,13 @@ def add_to_cart(book_id):
     """
     将指定图书添加到购物车（若已存在则数量 +1）
     """
-    quantity = int(request.form.get('quantity', 1))
+    try:
+        quantity = int(request.form.get('quantity', 1))
+        if quantity <= 0:
+            raise ValueError
+    except (ValueError, TypeError):
+        flash('数量必须为正整数。', 'warning')
+        return redirect(url_for('book_detail', book_id=book_id))
     conn = get_db_connection()
     with conn.cursor() as cursor:
         # 检查该用户购物车中是否已有此书

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -1,0 +1,45 @@
+import types
+import pytest
+import app as app_module
+
+class DummyUser:
+    def __init__(self, user_id=1):
+        self.id = user_id
+        self.is_authenticated = True
+        self.is_active = True
+        self.is_anonymous = False
+
+
+def test_calculate_cart_total(monkeypatch):
+    def fake_get_cart_items(user_id):
+        return [
+            {"price": 10.0, "quantity": 2},
+            {"price": 5.0, "quantity": 3},
+        ]
+
+    monkeypatch.setattr(app_module, "get_cart_items", fake_get_cart_items)
+    assert app_module.calculate_cart_total(1) == 10.0 * 2 + 5.0 * 3
+
+
+def test_add_to_cart_invalid_quantity(monkeypatch):
+    calls = {}
+
+    def fake_flash(msg, category):
+        calls["flash"] = msg
+
+    monkeypatch.setattr(app_module, "flash", fake_flash)
+
+    def fake_get_db_connection():
+        calls["db"] = True
+
+    monkeypatch.setattr(app_module, "get_db_connection", fake_get_db_connection)
+    monkeypatch.setattr(app_module, "current_user", DummyUser())
+
+    with app_module.app.test_request_context(
+        "/add_to_cart/1", method="POST", data={"quantity": "-1"}
+    ):
+        resp = app_module.add_to_cart.__wrapped__(1)
+
+    assert resp.status_code == 302
+    assert "数量必须为正整数" in calls["flash"]
+    assert "db" not in calls


### PR DESCRIPTION
## Summary
- add quantity validation when adding to cart
- add pytest unit tests for cart utilities

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415c7bd4fc832aa148f1ac784fd017