### PR TITLE
Fix order status mismatch

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS orders (
     id INT AUTO_INCREMENT PRIMARY KEY,                  -- 订单ID
     user_id INT NOT NULL,                               -- 会员ID
     total_amount DECIMAL(12,2) NOT NULL DEFAULT 0.00,   -- 订单总金额
-    status ENUM('已创建','已支付','已发货','已完成','已取消') NOT NULL DEFAULT '已创建',
+    status ENUM('created','paid','shipped','completed','canceled') NOT NULL DEFAULT 'created',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     shipping_address VARCHAR(255) NOT NULL,             -- 收货地址（下单时拷贝用户地址）

--- a/templates/admin/order_list.html
+++ b/templates/admin/order_list.html
@@ -20,18 +20,18 @@
       <td>{{ o.id }}</td>
       <td>{{ o.username }}</td>
       <td>¥{{ '%.2f'|format(o.total_amount) }}</td>
-      <td>{{ o.status }}</td>
+      <td>{{ status_map[o.status] }}</td>
       <td>{{ o.created_at }}</td>
       <td>
         <a href="{{ url_for('admin_order_detail', order_id=o.id) }}" class="btn btn-sm btn-info">查看</a>
         <form method="post" action="{{ url_for('admin_order_update_status', order_id=o.id) }}"
               style="display:inline;">
           <select name="status" class="form-control form-control-sm d-inline-block" style="width:auto;">
-            <option value="已创建"   {% if o.status=='已创建'   %} selected {% endif %}>已创建</option>
-            <option value="已支付"   {% if o.status=='已支付'   %} selected {% endif %}>已支付</option>
-            <option value="已发货"   {% if o.status=='已发货'   %} selected {% endif %}>已发货</option>
-            <option value="已完成"   {% if o.status=='已完成'   %} selected {% endif %}>已完成</option>
-            <option value="已取消"   {% if o.status=='已取消'   %} selected {% endif %}>已取消</option>
+            <option value="created"   {% if o.status=='created'   %} selected {% endif %}>已创建</option>
+            <option value="paid"      {% if o.status=='paid'      %} selected {% endif %}>已支付</option>
+            <option value="shipped"   {% if o.status=='shipped'   %} selected {% endif %}>已发货</option>
+            <option value="completed" {% if o.status=='completed' %} selected {% endif %}>已完成</option>
+            <option value="canceled"  {% if o.status=='canceled'  %} selected {% endif %}>已取消</option>
           </select>
           <button type="submit" class="btn btn-sm btn-primary">更新状态</button>
         </form>

--- a/templates/order_status.html
+++ b/templates/order_status.html
@@ -2,7 +2,7 @@
 {% block title %}订单详情{% endblock %}
 {% block content %}
 <h2>订单 #{{ order.id }} 详情</h2>
-<p>订单状态：<strong>{{ order.status }}</strong></p>
+<p>订单状态：<strong>{{ status_map[order.status] }}</strong></p>
 <p>下单时间：{{ order.created_at }}</p>
 <p>收货地址：{{ order.shipping_address }}</p>
 <p>联系电话：{{ order.contact_phone }}</p>
@@ -28,7 +28,7 @@
     </tbody>
 </table>
 
-{% if order.status == '已创建' %}
+{% if order.status == 'created' %}
 <p>请尽快付款，支付完成后我们会尽快发货。</p>
 {% endif %}
 


### PR DESCRIPTION
## Summary
- store order status values in English
- map order statuses to Chinese display names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684191f81488832ab6cf8df928ffd5c6